### PR TITLE
add __pycache__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /.idea/modules.xml
 /.idea/inspectionProfiles/profiles_settings.xml
 /.idea/vcs.xml
+/__pycache__
+/nodes/__pycache__
+/qss/__pycache__


### PR DESCRIPTION
__pycache__ directories are autogenerated when python run in the folder,
no need to save them