### PR TITLE
Add teleporter nodes

### DIFF
--- a/fcn_stargate.py
+++ b/fcn_stargate.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+###################################################################################
+#
+#  stargate.py
+#
+#  Copyright (c) 2022 Florian Foinant-Willig <ffw@2f2v.fr>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+###################################################################################
+
+TELEPORTER_FREE_ID=1
+
+class _Stargate:
+    knownTeleporters: dict = {}
+
+    def addTeleporter(self, input=None, output=None):
+        global TELEPORTER_FREE_ID
+        tele_id = TELEPORTER_FREE_ID
+        TELEPORTER_FREE_ID += 1
+        teleporter = Teleporter(input, output, tele_id)
+        self.knownTeleporters[tele_id] = teleporter
+        return tele_id
+
+    def renameTeleporter(self, old_id, new_id):
+        try:
+            self.knownTeleporters[new_id] = self.knownTeleporters[old_id]
+            return True
+        except:
+            return False
+
+    def getTeleporter(self, tele_id):
+        try:
+            return self.knownTeleporters[tele_id]
+        except:
+            return False
+
+    def removeTeleporter(self, tele_id):
+        try:
+            del self.knownTeleporters[tele_id]
+            return True
+        except:
+            return False
+
+stargate = _Stargate()
+
+class Teleporter:
+    def __init__(self, input, output, id):
+        self.input = input
+        self.output = output
+        self.id = id
+
+    def setInput(self, input):
+        self.input = input
+        self.checkValidity()
+
+    def setOutput(self, output):
+        self.output = output
+        self.checkValidity()
+
+    def checkValidity(self):
+        # remove teleporter w/o input nor output
+        if self.input is None and self.output is None:
+            stargate.removeTeleporter(self.id)

--- a/nodes/teleporter_in.py
+++ b/nodes/teleporter_in.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+###################################################################################
+#
+#  teleporter_in.py
+#
+#  Copyright (c) 2022 Florian Foinant-Willig <ffw@2f2v.fr>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+###################################################################################
+
+from fcn_conf import register_node
+from fcn_base_node import FCNNode
+from fcn_locator import icon
+from fcn_stargate import stargate
+
+@register_node
+class TeleporterInNode(FCNNode):
+
+    icon: str = icon("fcn_default.png")
+    op_title: str = "Teleporter In"
+    content_label_objname: str = "fcn_node_bg"
+
+    def __init__(self, scene):
+        self.id = stargate.addTeleporter(input=self)
+
+        super().__init__(scene=scene,
+                         inputs_init_list=[(0, "Id", 1, self.id, False), (0, "In", 0, 0, True)],
+                         outputs_init_list=[(0, "Id", 0, self.id, True)],
+                         width=250)
+
+    def collapse_node(self, collapse: bool = False):
+        super().collapse_node(collapse)
+        if collapse is True:
+            self.title = self.default_title + f' <{self.id}>'
+        else:
+            self.title = self.default_title
+
+    def eval_operation(self, sockets_input_data: list) -> list:
+        tele_id = sockets_input_data[0][0]
+
+        teleporter = stargate.getTeleporter(self.id)
+        if tele_id != self.id:
+            new_tele = stargate.getTeleporter(tele_id)
+            if new_tele:
+                new_tele.setInput(self)
+                if teleporter:
+                    teleporter.setInput(None)
+                teleporter = new_tele
+            else:
+                stargate.renameTeleporter(self.id, tele_id)
+            self.id = tele_id
+
+        if teleporter and teleporter.output is not None:
+            # force recompute at second extremity
+            teleporter.output.setData(sockets_input_data[1])
+            teleporter.output.markInvalid()
+            teleporter.output.eval()
+
+        return [self.id]

--- a/nodes/teleporter_out.py
+++ b/nodes/teleporter_out.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+###################################################################################
+#
+#  teleporter_out.py
+#
+#  Copyright (c) 2022 Florian Foinant-Willig <ffw@2f2v.fr>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+###################################################################################
+
+from fcn_conf import register_node
+from fcn_base_node import FCNNode
+from fcn_locator import icon
+from fcn_stargate import stargate
+
+@register_node
+class TeleporterOutNode(FCNNode):
+
+    icon: str = icon("fcn_default.png")
+    op_title: str = "Teleporter Out"
+    content_label_objname: str = "fcn_node_bg"
+
+    def __init__(self, scene):
+        self.id = stargate.addTeleporter(output=self)
+        self.data = [0]
+        super().__init__(scene=scene,
+                         inputs_init_list=[(0, "Id", 1, self.id, False)],
+                         outputs_init_list=[(0, "Id", 0, self.id, True), (0, "Out", 0, 0, True)],
+                         width=250)
+
+    def collapse_node(self, collapse: bool = False):
+        super().collapse_node(collapse)
+        if collapse is True:
+            self.title = self.default_title + f' <{self.id}>'
+        else:
+            self.title = self.default_title
+
+    def setData(self, data):
+        self.data = data
+
+    def eval_operation(self, sockets_input_data: list) -> list:
+        tele_id = sockets_input_data[0][0]
+
+        if tele_id != self.id:
+            teleporter = stargate.getTeleporter(self.id)
+            new_tele = stargate.getTeleporter(tele_id)
+            if new_tele:
+                new_tele.setOutput(self)
+                if teleporter:
+                    teleporter.setOutput(None)
+                teleporter = new_tele
+            else:
+                stargate.renameTeleporter(self.id, tele_id)
+            self.id = tele_id
+
+        return [[self.id], self.data]


### PR DESCRIPTION
Connect sockets without wires.

![Capture d’écran_2022-09-12_22-41-39](https://user-images.githubusercontent.com/10371513/189754755-aa0789f7-8cc5-4bb2-974c-7be9df62c658.png)

Can work throw sub-windows but can break easily if data slot is connected when id changes.