### PR TITLE
Input widget value

### DIFF
--- a/fcn_base_node.py
+++ b/fcn_base_node.py
@@ -38,7 +38,7 @@ node editor base framework.
 from collections import OrderedDict
 from typing import Union
 from math import floor
-from decimal import Decimal
+# from decimal import Decimal
 
 from qtpy.QtGui import QImage, QTextOption
 from qtpy.QtCore import QRectF, Qt
@@ -135,7 +135,7 @@ class FCNSocketView(QDMGraphicsSocket):
             self.input_widget.currentIndexChanged.connect(self.socket.node.onInputChanged)
 
         elif socket_input_index == 4:  # QPlainTextEdit
-            self.input_widget.setPlainText(str(socket_default_values))
+            self.input_widget.insertPlainText(str(socket_default_values))
             self.input_widget.textChanged.connect(lambda: self.socket.node.onInputChanged(
                 self.input_widget.toPlainText()))
             self.input_widget.setWordWrapMode(QTextOption.NoWrap)
@@ -148,55 +148,55 @@ class FCNSocketView(QDMGraphicsSocket):
         super().hoverLeaveEvent(event)
         self.mouse_over = False
 
-    def update_widget_value(self):
-        """Updates the value shown by the socket input widget.
-
-        Socket input/display widgets work in two directions. If no node is connected to the socket, they serve for quick
-        manipulation of the respective socket input value, i.e. the serve as an input field. However, if one a node is
-        connected to the socket, they will show the input value passed through that node. If multiple nodes are
-        connected to the socket, the input widget will show an arrow. This method evaluates the connected node and
-        displays the corresponding value in the input/display widget.
-        """
-
-        if self.socket.hasAnyEdge():
-            if len(self.socket.edges) == 1:
-                # If one edge is connected to the socket
-                connected_node: Node = self.socket.node.getInput(self.socket.index)
-                connected_output_index: int = self.socket.edges[0].getOtherSocket(self.socket).index
-                input_list = connected_node.eval(connected_output_index)
-
-                if isinstance(self.input_widget, QLineEdit):
-                    if len(input_list) == 1:
-                        # List with on element (maybe another list)
-                        if isinstance(input_list[0], int) or isinstance(input_list[0], float):
-                            self.input_widget.setText("%.2E" % Decimal(str(input_list[0])))
-                        elif isinstance(input_list[0], str):
-                            self.input_widget.setText(input_list[0])
-                        elif isinstance(input_list[0], list):
-                            self.input_widget.setText("<list>")
-                        else:
-                            self.input_widget.setText("<unknown>")
-                    else:
-                        self.input_widget.setText("<list>")
-
-                elif isinstance(self.input_widget, QSlider):
-                    if isinstance(input_list[0], int) or isinstance(input_list[0], float):
-                        self.input_widget.setValue(int(input_list[0]))
-
-                elif isinstance(self.input_widget, QComboBox):
-                    if isinstance(input_list[0], int):
-                        self.input_widget.setCurrentIndex(input_list[0])
-
-                elif isinstance(self.input_widget, QPlainTextEdit):
-                    if len(input_list) == 1:
-                        self.input_widget.setPlainText(str(input_list[0]))
-                    else:
-                        self.input_widget.setPlainText('\n'.join(input_list[0]))
-
-            else:
-                # Multiple edges at one socket
-                if isinstance(self.input_widget, QLineEdit):
-                    self.input_widget.setText("<multi>")
+    # def update_widget_value(self):
+    #     """Updates the value shown by the socket input widget.
+    #
+    #     Socket input/display widgets work in two directions. If no node is connected to the socket, they serve for quick
+    #     manipulation of the respective socket input value, i.e. the serve as an input field. However, if one a node is
+    #     connected to the socket, they will show the input value passed through that node. If multiple nodes are
+    #     connected to the socket, the input widget will show an arrow. This method evaluates the connected node and
+    #     displays the corresponding value in the input/display widget.
+    #     """
+    #
+    #     if self.socket.hasAnyEdge():
+    #         if len(self.socket.edges) == 1:
+    #             # If one edge is connected to the socket
+    #             connected_node: Node = self.socket.node.getInput(self.socket.index)
+    #             connected_output_index: int = self.socket.edges[0].getOtherSocket(self.socket).index
+    #             input_list = connected_node.eval(connected_output_index)
+    #
+    #             if isinstance(self.input_widget, QLineEdit):
+    #                 if len(input_list) == 1:
+    #                     # List with on element (maybe another list)
+    #                     if isinstance(input_list[0], int) or isinstance(input_list[0], float):
+    #                         self.input_widget.setText("%.2E" % Decimal(str(input_list[0])))
+    #                     elif isinstance(input_list[0], str):
+    #                         self.input_widget.setText(input_list[0])
+    #                     elif isinstance(input_list[0], list):
+    #                         self.input_widget.setText("<list>")
+    #                     else:
+    #                         self.input_widget.setText("<unknown>")
+    #                 else:
+    #                     self.input_widget.setText("<list>")
+    #
+    #             elif isinstance(self.input_widget, QSlider):
+    #                 if isinstance(input_list[0], int) or isinstance(input_list[0], float):
+    #                     self.input_widget.setValue(int(input_list[0]))
+    #
+    #             elif isinstance(self.input_widget, QComboBox):
+    #                 if isinstance(input_list[0], int):
+    #                     self.input_widget.setCurrentIndex(input_list[0])
+    #
+    #             elif isinstance(self.input_widget, QPlainTextEdit):
+    #                 if len(input_list) == 1:
+    #                     self.input_widget.insertPlainText(str(input_list[0]))
+    #                 else:
+    #                     self.input_widget.insertPlainText('\n'.join(input_list[0]))
+    #
+    #         else:
+    #             # Multiple edges at one socket
+    #             if isinstance(self.input_widget, QLineEdit):
+    #                 self.input_widget.setText("<multi>")
 
     def update_widget_status(self):
         """Updates the input widget state.
@@ -209,7 +209,7 @@ class FCNSocketView(QDMGraphicsSocket):
             # If socket is connected
             # self.input_widget.setDisabled(True)
             self.input_widget.hide()
-            self.update_widget_value()
+            # self.update_widget_value()
 
         else:
             # self.input_widget.setDisabled(False)

--- a/fcn_base_node.py
+++ b/fcn_base_node.py
@@ -207,11 +207,13 @@ class FCNSocketView(QDMGraphicsSocket):
 
         if self.socket.hasAnyEdge():
             # If socket is connected
-            self.input_widget.setDisabled(True)
+            # self.input_widget.setDisabled(True)
+            self.input_widget.hide()
             self.update_widget_value()
 
         else:
-            self.input_widget.setDisabled(False)
+            # self.input_widget.setDisabled(False)
+            self.input_widget.show()
 
     def paint(self, painter, qstyle_option_graphics_item, widget=None):
         if self.mouse_over:
@@ -345,6 +347,12 @@ class FCNNodeContentView(QDMNodeContentWidget):
             self.output_widgets.append(socket.grSocket.label_widget)
             self.layout.addRow(socket.grSocket.input_widget, socket.grSocket.label_widget)
         self.show()  # Hack for recalculating content geometry before updating socket position.
+
+        # Levels heights of labels and widgets to prevent layout from jumping when individual widgets are shown/hidden.
+        if self.node.auto_layout is True:
+            # Hack: Not for nodes with manual layout management
+            for idx, input_label in enumerate(self.input_labels):
+                input_label.setFixedHeight(self.input_widgets[idx].height())
 
     def update_content_ui(self, sockets_input_data: list) -> None:
         """Updates the node content ui.
@@ -557,7 +565,7 @@ class FCNNode(Node):
     default_title: str
 
     def __init__(self, scene: Scene, inputs_init_list: list = None, outputs_init_list: list = None,
-                 width: int = 250):
+                 width: int = 250, auto_layout: bool = True):
         """Constructor of the FCNNode class.
 
         Note:
@@ -580,10 +588,13 @@ class FCNNode(Node):
         :type outputs_init_list: list
         :param width: Width of the node.
         :type width: int
+        :param auto_layout: Is node height managed by Qt layout manager or manual?
+        :type auto_layout: bool
         """
 
         self.inputs_init_list: list = inputs_init_list
         self.output_init_list: list = outputs_init_list
+        self.auto_layout = auto_layout
 
         super().__init__(scene, self.__class__.op_title, self.inputs_init_list, self.output_init_list)
         self.default_title = self.title

--- a/fcn_base_node.py
+++ b/fcn_base_node.py
@@ -148,56 +148,6 @@ class FCNSocketView(QDMGraphicsSocket):
         super().hoverLeaveEvent(event)
         self.mouse_over = False
 
-    # def update_widget_value(self):
-    #     """Updates the value shown by the socket input widget.
-    #
-    #     Socket input/display widgets work in two directions. If no node is connected to the socket, they serve for quick
-    #     manipulation of the respective socket input value, i.e. the serve as an input field. However, if one a node is
-    #     connected to the socket, they will show the input value passed through that node. If multiple nodes are
-    #     connected to the socket, the input widget will show an arrow. This method evaluates the connected node and
-    #     displays the corresponding value in the input/display widget.
-    #     """
-    #
-    #     if self.socket.hasAnyEdge():
-    #         if len(self.socket.edges) == 1:
-    #             # If one edge is connected to the socket
-    #             connected_node: Node = self.socket.node.getInput(self.socket.index)
-    #             connected_output_index: int = self.socket.edges[0].getOtherSocket(self.socket).index
-    #             input_list = connected_node.eval(connected_output_index)
-    #
-    #             if isinstance(self.input_widget, QLineEdit):
-    #                 if len(input_list) == 1:
-    #                     # List with on element (maybe another list)
-    #                     if isinstance(input_list[0], int) or isinstance(input_list[0], float):
-    #                         self.input_widget.setText("%.2E" % Decimal(str(input_list[0])))
-    #                     elif isinstance(input_list[0], str):
-    #                         self.input_widget.setText(input_list[0])
-    #                     elif isinstance(input_list[0], list):
-    #                         self.input_widget.setText("<list>")
-    #                     else:
-    #                         self.input_widget.setText("<unknown>")
-    #                 else:
-    #                     self.input_widget.setText("<list>")
-    #
-    #             elif isinstance(self.input_widget, QSlider):
-    #                 if isinstance(input_list[0], int) or isinstance(input_list[0], float):
-    #                     self.input_widget.setValue(int(input_list[0]))
-    #
-    #             elif isinstance(self.input_widget, QComboBox):
-    #                 if isinstance(input_list[0], int):
-    #                     self.input_widget.setCurrentIndex(input_list[0])
-    #
-    #             elif isinstance(self.input_widget, QPlainTextEdit):
-    #                 if len(input_list) == 1:
-    #                     self.input_widget.insertPlainText(str(input_list[0]))
-    #                 else:
-    #                     self.input_widget.insertPlainText('\n'.join(input_list[0]))
-    #
-    #         else:
-    #             # Multiple edges at one socket
-    #             if isinstance(self.input_widget, QLineEdit):
-    #                 self.input_widget.setText("<multi>")
-
     def update_widget_status(self):
         """Updates the input widget state.
 
@@ -207,10 +157,7 @@ class FCNSocketView(QDMGraphicsSocket):
 
         if self.socket.hasAnyEdge():
             # If socket is connected
-            # self.input_widget.setDisabled(True)
             self.input_widget.hide()
-            # self.update_widget_value()
-
         else:
             # self.input_widget.setDisabled(False)
             self.input_widget.show()
@@ -817,7 +764,7 @@ class FCNNode(Node):
             output_data: list = self.eval_primer()
             if output_data:
                 return output_data[index]
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, SyntaxError, NameError) as e:
             self.markInvalid()
             self.grNode.setToolTip(str(e))
             self.markDescendantsDirty()

--- a/nodes/python_node.py
+++ b/nodes/python_node.py
@@ -22,7 +22,7 @@
 #
 #
 ###################################################################################
-from qtpy.QtWidgets import QSizePolicy, QTextEdit
+# from qtpy.QtWidgets import QSizePolicy, QTextEdit
 
 from fcn_conf import register_node
 from fcn_base_node import FCNNode
@@ -41,30 +41,30 @@ class PythonNode(FCNNode):
         width = 400
         super().__init__(scene=scene,
                          inputs_init_list=[(3, "Code", 4, "#enter python code\noutput_data=input_data",
-                                            False, ('str', )),
+                                            False, ("str", )),
                                            (0, "In", 0, "", True)],
                          outputs_init_list=[(0, "Out", 0, 0, True)],
-                         width=width, auto_layout=False)
+                         width=width, auto_layout=True)
 
-        # Manually set node and content size
-        self.grNode.height = width
-        self.grNode.default_height = width
-        self.grNode.width = width
-        self.content.setFixedHeight(self.grNode.height - self.grNode.title_vertical_padding -
-                                    self.grNode.edge_padding - self.grNode.title_height)
-        self.content.setFixedWidth(self.grNode.width - 2 * self.grNode.edge_padding)
-
-        # Adjust content layout by expanding QTextEdit to maximum
-        text_edit: QTextEdit = self.content.input_widgets[0]
-        text_edit_policy: QSizePolicy = text_edit.sizePolicy()
-        text_edit_policy.setVerticalStretch(QSizePolicy.Expanding)
-        text_edit.setSizePolicy(text_edit_policy)
-
-        text_edit.hide()  # Hack: Updates widget geometry to calculate the correct socket positions.
-        text_edit.show()  # Hack: See above
-
-        # Update socket position
-        self.place_sockets()
+        # # Manually set node and content size
+        # self.grNode.height = width
+        # self.grNode.default_height = width
+        # self.grNode.width = width
+        # self.content.setFixedHeight(self.grNode.height - self.grNode.title_vertical_padding -
+        #                             self.grNode.edge_padding - self.grNode.title_height)
+        # self.content.setFixedWidth(self.grNode.width - 2 * self.grNode.edge_padding)
+        #
+        # # Adjust content layout by expanding QTextEdit to maximum
+        # text_edit: QTextEdit = self.content.input_widgets[0]
+        # text_edit_policy: QSizePolicy = text_edit.sizePolicy()
+        # text_edit_policy.setVerticalStretch(QSizePolicy.Expanding)
+        # text_edit.setSizePolicy(text_edit_policy)
+        #
+        # text_edit.hide()  # Hack: Updates widget geometry to calculate the correct socket positions.
+        # text_edit.show()  # Hack: See above
+        #
+        # # Update socket position
+        # self.place_sockets()
 
     def eval_operation(self, sockets_input_data: list) -> list:
         code: str = str(sockets_input_data[0][0])

--- a/nodes/python_node.py
+++ b/nodes/python_node.py
@@ -22,7 +22,7 @@
 #
 #
 ###################################################################################
-# from qtpy.QtWidgets import QSizePolicy, QTextEdit
+from qtpy.QtWidgets import QSizePolicy, QTextEdit
 
 from fcn_conf import register_node
 from fcn_base_node import FCNNode
@@ -44,27 +44,28 @@ class PythonNode(FCNNode):
                                             False, ("str", )),
                                            (0, "In", 0, "", True)],
                          outputs_init_list=[(0, "Out", 0, 0, True)],
-                         width=width, auto_layout=True)
+                         width=width, auto_layout=False)
 
-        # # Manually set node and content size
-        # self.grNode.height = width
-        # self.grNode.default_height = width
-        # self.grNode.width = width
-        # self.content.setFixedHeight(self.grNode.height - self.grNode.title_vertical_padding -
-        #                             self.grNode.edge_padding - self.grNode.title_height)
-        # self.content.setFixedWidth(self.grNode.width - 2 * self.grNode.edge_padding)
-        #
-        # # Adjust content layout by expanding QTextEdit to maximum
-        # text_edit: QTextEdit = self.content.input_widgets[0]
-        # text_edit_policy: QSizePolicy = text_edit.sizePolicy()
-        # text_edit_policy.setVerticalStretch(QSizePolicy.Expanding)
-        # text_edit.setSizePolicy(text_edit_policy)
-        #
-        # text_edit.hide()  # Hack: Updates widget geometry to calculate the correct socket positions.
-        # text_edit.show()  # Hack: See above
-        #
-        # # Update socket position
-        # self.place_sockets()
+        # Manually set node and content size
+        self.grNode.height = width
+        self.grNode.default_height = width
+        self.grNode.width = width
+        self.content.setFixedHeight(self.grNode.height - self.grNode.title_vertical_padding -
+                                    self.grNode.edge_padding - self.grNode.title_height)
+        self.content.setFixedWidth(self.grNode.width - 2 * self.grNode.edge_padding)
+
+        # Adjust content layout by expanding QTextEdit to maximum
+        text_edit: QTextEdit = self.content.input_widgets[0]
+        text_edit_policy: QSizePolicy = text_edit.sizePolicy()
+        text_edit_policy.setVerticalStretch(QSizePolicy.Expanding)
+        text_edit.setSizePolicy(text_edit_policy)
+
+        text_edit.hide()  # Hack: Updates widget geometry to calculate the correct socket positions.
+        text_edit.show()  # Hack: See above
+        self.content.input_labels[0].setFixedHeight(text_edit.height())  # Levels heights of code label and widget
+
+        # Update socket position
+        self.place_sockets()
 
     def eval_operation(self, sockets_input_data: list) -> list:
         code: str = str(sockets_input_data[0][0])

--- a/nodes/python_node.py
+++ b/nodes/python_node.py
@@ -41,10 +41,10 @@ class PythonNode(FCNNode):
         width = 400
         super().__init__(scene=scene,
                          inputs_init_list=[(3, "Code", 4, "#enter python code\noutput_data=input_data",
-                                            False, ('string', )),
+                                            False, ('str', )),
                                            (0, "In", 0, "", True)],
                          outputs_init_list=[(0, "Out", 0, 0, True)],
-                         width=width)
+                         width=width, auto_layout=False)
 
         # Manually set node and content size
         self.grNode.height = width


### PR DESCRIPTION
For simplicity, input widgets of connected sockets are hidden. This eliminates the need to update widget values based on input nodes. 

![widget_value_issue](https://user-images.githubusercontent.com/39261150/194014130-343e4ef0-c422-4951-a6b5-ceb35711a722.png)
