### PR TITLE
Update to FreeCAD version >=0.22.0 and Qt6/pyside6

### DIFF
--- a/core/nodes_window.py
+++ b/core/nodes_window.py
@@ -3,7 +3,8 @@ from fnmatch import fnmatch
 
 from qtpy.QtGui import QIcon, QKeySequence
 from qtpy.QtWidgets import QApplication, QMdiArea, QWidget, QDockWidget, QAction, QMessageBox, QFileDialog, QMenu
-from qtpy.QtCore import Qt, QSignalMapper
+from qtpy.QtCore import Qt
+from functools import partial
 
 from nodeeditor.node_editor_window import NodeEditorWindow
 from nodeeditor.node_edge import Edge
@@ -31,7 +32,6 @@ class FCNWindow(NodeEditorWindow):
     name_product: str
     empty_icon: QIcon
     mdi_area: QMdiArea
-    window_mapper: QSignalMapper
     act_close: QAction
     act_close_all: QAction
     act_tile: QAction
@@ -66,8 +66,6 @@ class FCNWindow(NodeEditorWindow):
         self.mdi_area.setTabsMovable(True)
         self.setCentralWidget(self.mdi_area)
         self.mdi_area.subWindowActivated.connect(self.update_menus)
-        self.window_mapper = QSignalMapper(self)
-        self.window_mapper.mapped[QWidget].connect(self.set_active_sub_window)
 
         # self.create_nodes_dock()
         self.createActions()
@@ -230,8 +228,7 @@ class FCNWindow(NodeEditorWindow):
             action = self.window_menu.addAction(text)
             action.setCheckable(True)
             action.setChecked(child is self.getCurrentNodeEditorWidget())
-            action.triggered.connect(self.window_mapper.map)
-            self.window_mapper.setMapping(action, window)
+            action.triggered.connect(partial(self.set_active_sub_window, window))
 
     # def on_window_nodes_toolbar(self):
     #     if self.nodes_dock.isVisible():

--- a/lib/nodeeditor/node_graphics_view.py
+++ b/lib/nodeeditor/node_graphics_view.py
@@ -106,7 +106,7 @@ class QDMGraphicsView(QGraphicsView):
 
     def initUI(self):
         """Set up this ``QGraphicsView``"""
-        self.setRenderHints(QPainter.Antialiasing | QPainter.HighQualityAntialiasing | QPainter.TextAntialiasing | QPainter.SmoothPixmapTransform)
+        self.setRenderHints(QPainter.Antialiasing | QPainter.TextAntialiasing | QPainter.SmoothPixmapTransform)
 
         self.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
 
@@ -121,7 +121,7 @@ class QDMGraphicsView(QGraphicsView):
 
     def isSnappingEnabled(self, event: 'QInputEvent' = None) -> bool:
         """Returns ``True`` if snapping is currently enabled"""
-        return EDGE_SNAPPING and (event.modifiers() & Qt.CTRL) if event else True
+        return EDGE_SNAPPING and (event.modifiers() & Qt.ControlModifier) if event else True
 
     def resetMode(self):
         """Helper function to re-set the grView's State Machine state to the default"""
@@ -199,7 +199,7 @@ class QDMGraphicsView(QGraphicsView):
             print("  Edges:")
             for edge in self.grScene.scene.edges: print("\t", edge, "\n\t\tgrEdge:", edge.grEdge if edge.grEdge is not None else None)
 
-            if event.modifiers() & Qt.CTRL:
+            if event.modifiers() & Qt.ControlModifier:
                 print("  Graphic Items in GraphicScene:")
                 for item in self.grScene.items():
                     print('    ', item)
@@ -260,7 +260,7 @@ class QDMGraphicsView(QGraphicsView):
             item = self.snapping.getSnappedSocketItem(event)
 
         if isinstance(item, QDMGraphicsSocket):
-            if self.mode == MODE_NOOP and event.modifiers() & Qt.CTRL:
+            if self.mode == MODE_NOOP and event.modifiers() & Qt.ControlModifier:
                 socket = item.socket
                 if socket.hasAnyEdge():
                     self.mode = MODE_EDGES_REROUTING

--- a/nodes/spatial/spatial_voronoi_on_sld.py
+++ b/nodes/spatial/spatial_voronoi_on_sld.py
@@ -26,7 +26,7 @@ from math import fabs
 
 import numpy as np
 from scipy.spatial import Voronoi
-from scipy import rand
+from numpy.random import rand
 from collections import defaultdict
 import itertools
 


### PR DESCRIPTION
Those changes were needed to make Nodes workbench start and execute in FreeCAD 0.22.0dev with Qt 6.7.2/pyside6 using python 3.12.4

I implemented them and verified by using the Voronoi-on-solid features of Nodes with my recent development build (rev 38462) of FreeCAD:
![Bildschirmfoto vom 2024-08-14 08-33-08](https://github.com/user-attachments/assets/2799e4e8-5519-458f-9772-5e356b08d65f)
